### PR TITLE
Fix boolean field handling

### DIFF
--- a/src/client/mixins/registrant-aware.ts
+++ b/src/client/mixins/registrant-aware.ts
@@ -1,17 +1,19 @@
+import On24 from 'node-on24';
+import { ListEventRegistrantResult, Registrant, ForgetRegistrantResult } from 'node-on24/dist/interfaces';
 
 export class RegistrantAwareMixin {
 
-  client: any;
+  client: On24;
 
-  public getEventRegistrantByEmail(eventId: number, email: string): Promise<any> {
+  public getEventRegistrantByEmail(eventId: number, email: string): Promise<ListEventRegistrantResult> {
     return this.client.analytics.listEventRegistrants(eventId, { email });
   }
 
-  public createEventRegistrant(eventId: number, registrant: Record<string, any>): Promise<any> {
+  public createEventRegistrant(eventId: number, registrant: Record<string, any>): Promise<Registrant> {
     return this.client.registration.createRegistrant(eventId, registrant);
   }
 
-  public forgetEventRegistrantByEmail(eventId: number, email: string): Promise<any> {
+  public forgetEventRegistrantByEmail(eventId: number, email: string): Promise<ForgetRegistrantResult> {
     return this.client.registration.forgetRegistrant(email, eventId);
   }
 

--- a/src/client/mixins/registrant-aware.ts
+++ b/src/client/mixins/registrant-aware.ts
@@ -1,3 +1,5 @@
+/*tslint:disable:import-name*/
+
 import On24 from 'node-on24';
 import { ListEventRegistrantResult, Registrant, ForgetRegistrantResult } from 'node-on24/dist/interfaces';
 

--- a/src/core/base-step.ts
+++ b/src/core/base-step.ts
@@ -98,7 +98,7 @@ export abstract class BaseStep {
       } else if (fieldedObject[key] === false || fieldedObject[key] === 'false') {
         fieldedObject[key] = 'N';
       }
-    })
+    });
   }
 
   protected pass(message: string, messageArgs: any[] = [], records: StepRecord[] = []): RunStepResponse {

--- a/src/core/base-step.ts
+++ b/src/core/base-step.ts
@@ -91,6 +91,16 @@ export abstract class BaseStep {
     return util.compare(operator, actualValue, value);
   }
 
+  convertBooleanToOn24YesNo(fieldedObject: any) {
+    Object.keys(fieldedObject).forEach((key) => {
+      if (fieldedObject[key] === true || fieldedObject[key] === 'true') {
+        fieldedObject[key] = 'Y';
+      } else if (fieldedObject[key] === false || fieldedObject[key] === 'false') {
+        fieldedObject[key] = 'N';
+      }
+    })
+  }
+
   protected pass(message: string, messageArgs: any[] = [], records: StepRecord[] = []): RunStepResponse {
     const response = this.outcomelessResponse(message, messageArgs);
     response.setOutcome(RunStepResponse.Outcome.PASSED);

--- a/src/steps/registrants/check-registrant-field.ts
+++ b/src/steps/registrants/check-registrant-field.ts
@@ -53,14 +53,16 @@ export class CheckRegistrantField extends BaseStep implements StepInterface {
   }];
 
   async executeStep(step: Step): Promise<RunStepResponse> {
-    let apiRes: any;
     const stepData: any = step.getData().toJavaScript();
+    this.convertBooleanToOn24YesNo(stepData);
+
     const eventId: number = stepData.eventId;
     const email: string = stepData.email;
     const field: string = stepData.field;
     const expectedValue: string = stepData.expectedValue;
     const operator: string = stepData.operator.toLowerCase();
     let actualValue: any;
+    let apiRes: any;
 
     // Search ON24 for registrant.
     try {

--- a/src/steps/registrants/create-registrant.ts
+++ b/src/steps/registrants/create-registrant.ts
@@ -38,14 +38,16 @@ export class CreateRegistrant extends BaseStep implements StepInterface {
   }];
 
   async executeStep(step: Step): Promise<RunStepResponse> {
-    let apiRes: any;
     const stepData: any = step.getData().toJavaScript();
     const eventId: number = stepData.eventId;
     const registrant: Record<string, any> = stepData.registrant;
 
+    // Convert any true/false values (or strings) to expected 'Y' or 'N' values.
+    this.convertBooleanToOn24YesNo(registrant);
+
     // Search ON24 for registrant.
     try {
-      apiRes = await this.client.createEventRegistrant(eventId, registrant);
+      const apiRes = await this.client.createEventRegistrant(eventId, registrant);
       const registrantRecord = this.keyValue('registrant', 'Created Registrant', apiRes);
       return this.pass('Successfully created registrant %s for event %d.', [apiRes.email, eventId], [registrantRecord]);
     } catch (e) {

--- a/test/scenarios/Registrant - CRUD.crank.yml
+++ b/test/scenarios/Registrant - CRUD.crank.yml
@@ -15,8 +15,11 @@ steps:
       firstname: '{{test.first}}'
       lastname: '{{test.last}}'
       company: '{{test.org}}'
+      marketingemail: true
 - step: Then the firstname field on ON24 registrant {{test.email}} for event 2211253 should be {{test.first}}
 - step: And the lastname field on ON24 registrant {{test.email}} for event 2211253 should not be {{test.first}}
 - step: And the company field on ON24 registrant {{test.email}} for event 2211253 should contain Laiz
 - step: And the createtimestamp field on ON24 registrant {{test.email}} for event 2211253 should be less than 2050-01-01
+- step: And the marketingemail field on ON24 registrant {{test.email}} for event 2211253 should be true
+- step: And the marketingemail field on ON24 registrant {{test.email}} for event 2211253 should be Y
 - step: Finally, forget that {{test.email}} registered for ON24 event 2211253

--- a/test/steps/registrants/check-registrant-field.ts
+++ b/test/steps/registrants/check-registrant-field.ts
@@ -89,6 +89,24 @@ describe('CheckRegistrantField', () => {
     expect(registrantEmail.type).to.equal(FieldDefinition.Type.EMAIL);
   });
 
+  it('should convert true/false to Y/N before check', async () => {
+    // Stub a response that matches expectations.
+    const expectedRegistrant: any = {someField: 'N'};
+    apiClientStub.getEventRegistrantByEmail.resolves({registrants: [expectedRegistrant]});
+
+    // Set step data corresponding to expectations (note false instead of N).
+    protoStep.setData(Struct.fromJavaScript({
+      field: 'someField',
+      expectedValue: false,
+      email: 'anything@example.com',
+      operator: 'be',
+      eventId: 123,
+    }));
+
+    const response: RunStepResponse = await stepUnderTest.executeStep(protoStep);
+    expect(response.getOutcome()).to.equal(RunStepResponse.Outcome.PASSED);
+  });
+
   it('should respond with pass if API client resolves expected data', async () => {
     // Stub a response that matches expectations.
     const expectedRegistrant: any = {someField: 'Expected Value'};

--- a/test/steps/registrants/create-registrant.ts
+++ b/test/steps/registrants/create-registrant.ts
@@ -73,6 +73,28 @@ describe('CreateRegistrant', () => {
     expect(registrantEmail.type).to.equal(FieldDefinition.Type.EMAIL);
   });
 
+  it('should convert true/false to Y/N before creation', async () => {
+    apiClientStub.createEventRegistrant.resolves();
+    protoStep.setData(Struct.fromJavaScript({
+      eventId: 123,
+      registrant: {
+        boolTrue: true,
+        stringTrue: 'true',
+        boolFalse: false,
+        stringFalse: 'false',
+      },
+    }));
+
+    await stepUnderTest.executeStep(protoStep);
+
+    expect(apiClientStub.createEventRegistrant).to.have.been.calledWith(123, {
+      boolTrue: 'Y',
+      stringTrue: 'Y',
+      boolFalse: 'N',
+      stringFalse: 'N',
+    });
+  });
+
   it('should respond with pass if API client resolves expected data', async () => {
     // Stub a response that matches expectations.
     const expectedRegistrant: any = {email: 'expected@example.com'};


### PR DESCRIPTION
ON24 uses `Y` and `N` values for boolean/checkbox fields, while `crank` will pass boolean `true` and `false` values (as well as string equivalents).  This PR converts the client string/bool values into their ON24 equivalents prior to creation and field check.